### PR TITLE
Updating Travis CI repository information for badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gradle ENSIME Plugin
 
 [![Join the chat at https://gitter.im/ensime/ensime-gradle](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ensime/ensime-gradle?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/coacoas/gradle-ensime.svg)](https://travis-ci.org/coacoas/gradle-ensime)
+[![Build Status](https://travis-ci.org/ensime/ensime-gradle.svg)](https://travis-ci.org/ensime/ensime-gradle)
 
 ## Purposes
 


### PR DESCRIPTION
The readme was still referencing the coacoas/gradle-ensime repository.Updating for the move to ensime/ensime-gradle