### PR TITLE
Ark/subproject fix

### DIFF
--- a/src/main/groovy/net/coacoas/gradle/plugins/EnsimeTask.groovy
+++ b/src/main/groovy/net/coacoas/gradle/plugins/EnsimeTask.groovy
@@ -98,7 +98,7 @@ class EnsimeTask extends DefaultTask {
               }
               allSubs
           }
-        })
+        }.unique { a, b -> a.get("name")+a.get("target") <=> b.get("name")+b.get("target") })
       }
     }
 

--- a/src/test/groovy/net/coacoas/gradle/plugins/SimpleProjectTest.groovy
+++ b/src/test/groovy/net/coacoas/gradle/plugins/SimpleProjectTest.groovy
@@ -153,6 +153,13 @@ public class SimpleProjectTest extends Specification implements ProjectSpecifica
         then:
         module1BuildFile.exists()
         module2BuildFile.exists()
+        // top-level .ensime
+        File rootEnsime = new File(testProjectDir.root, '.ensime')
+        String rootConfig = rootEnsime.readLines()
+        1 == ( rootConfig =~ /:name \"module1\"/ ).count // should only be 1 "module1" subproject
+        1 == ( rootConfig =~ /:name \"module2\"/ ).count // should only be 1 "module2" subproject
+
+        // module1 and module2 .ensime
         File ensime1 = new File(module1BuildFile.getParent(), '.ensime')
         File ensime2 = new File(module2BuildFile.getParent(), '.ensime')
         ensime1.exists()


### PR DESCRIPTION
This change will add any projects listed in `dependsOnModules` into the `subprojects` list. I also added a test.

This will make ensime aware of dependencies added via project. For example `compile(project(":foo"))`.