### PR TITLE
Added options for adding additional sources to the .ensime file

### DIFF
--- a/src/main/groovy/net/coacoas/gradle/plugins/Ensime.groovy
+++ b/src/main/groovy/net/coacoas/gradle/plugins/Ensime.groovy
@@ -74,6 +74,9 @@ class EnsimeModel {
   List<String> referenceSourceRoots = []
   List<String> compilerArgs = []
   FormattingPrefsModel formatting = new FormattingPrefsModel()
+  List<String> additionalSources = []
+  List<String> additionalJars = []
+  List<String> additionalDocs = []
 
   boolean downloadSources = true
   boolean downloadJavadoc = true
@@ -92,6 +95,9 @@ class EnsimeModel {
             ", compilerArgs=" + compilerArgs +
             ", downloadSources = " + downloadSources +
             ", downloadJavadoc = " + downloadJavadoc +
+            ", additionalSources = " + additionalSources +
+            ", additionalJars = " + additionalJars +
+            ", additionalDocs = " + additionalDocs +
 	    ", ${formatting}" +
             '}';
   }

--- a/src/main/groovy/net/coacoas/gradle/plugins/SubprojectModule.groovy
+++ b/src/main/groovy/net/coacoas/gradle/plugins/SubprojectModule.groovy
@@ -74,13 +74,13 @@ class SubprojectModule {
 
     List<String> getReferenceSourceRoots() {
         return getArtifacts(project.configurations.testCompile, SourcesArtifact)
-                .collect { it.file.absolutePath }
+                .collect { it.file.absolutePath } .addAll(model.additionalSources)
 
     }
 
     List<String> getDocJars() {
         return getArtifacts(project.configurations.testCompile, JavadocArtifact)
-                .collect { it.file.absolutePath }
+                .collect { it.file.absolutePath } .addAll(model.additionalDocs)
     }
 
     List<String> getSourceSets() {
@@ -132,7 +132,7 @@ class SubprojectModule {
         project.logger.debug("EnsimeModule: Writing depends-on-modules: ${dependencies}")
 
         //  Classpath modifications
-        properties.put("compile-deps", classPath(compileConfigs()))
+        properties.put("compile-deps", classPath(compileConfigs()).addAll(model.additionalJars))
         properties.put("test-deps", classPath(testCompileConfigs()))
 
         // reference-source-roots ...


### PR DESCRIPTION
**Note: this is still missing tests**
I had trouble with a gradle plugin adding dependencies that werent detected by ensime, so i added 3 config fields to add files to some corresponding fields in the .ensime file, directly from the buildscripts.

 - `additionalSources` -> `referenced-source-roots`
 - `additionalJars` -> `compile-deps`
 - `additionalDocs` -> `doc-jars`

these options are all appended to the detected lists